### PR TITLE
Refactor to use VersionsProvider

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/endorsements.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/endorsements.html
@@ -1,5 +1,5 @@
 {%
-  if record.endorsements | selectattr('endorsement_list') | list
+  if record.endorsements
       and config.NOTIFY_PHASE_1_ENABLED
 %}
 <div class="sidebar-container">

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/EndorsementsDisplay.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/EndorsementsDisplay.js
@@ -1,8 +1,8 @@
-import React, {Component} from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import {Grid, Accordion, Icon, Header, Segment, Table} from "semantic-ui-react";
 import {i18next} from "@translations/invenio_app_rdm/i18next";
-import { useVersions } from "./VersionsProvider";
+import { useSharedVersions } from "./useSharedVersions";
 
 const EndorsementsDisplayContent = ({ record, allVersions, versionsLoading, versionsError }) => {
   const [activeIndices, setActiveIndices] = React.useState([]);
@@ -52,7 +52,7 @@ const EndorsementsDisplayContent = ({ record, allVersions, versionsLoading, vers
   }
 
   const getVersionWithIcon = (review, versions, latestVersion) => {
-    if(versions === {})
+    if(Object.keys(versions).length === 0)
       return <>v{review.index}</>;
 
     const isLatest = review.index === latestVersion.index;
@@ -133,7 +133,6 @@ const EndorsementsDisplayContent = ({ record, allVersions, versionsLoading, vers
       {validEndorsements.map((endorsement, endorsementIndex) => {
         const mostRecentEndorsement = getMostRecent(endorsement.endorsement_list);
         const mostRecentReview = getMostRecent(endorsement.review_list);
-        const latestVersion = allVersions.hits.find(item => item.is_latest);
         const sortedReviews = getSortedReviews(endorsement.review_list);
         const hasReviews = endorsement.review_list.length > 0;
 
@@ -223,10 +222,10 @@ EndorsementsDisplayContent.propTypes = {
 };
 
 export const EndorsementsDisplay = ({ record }) => {
-  const { allVersions, versionsLoading, versionsError } = useVersions();
-  
+  const { allVersions, versionsLoading, versionsError } = useSharedVersions(record);
+
   return (
-    <EndorsementsDisplayContent 
+    <EndorsementsDisplayContent
       record={record}
       allVersions={allVersions}
       versionsLoading={versionsLoading}

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/EndorsementsDisplay.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/EndorsementsDisplay.js
@@ -2,97 +2,30 @@ import React, {Component} from "react";
 import PropTypes from "prop-types";
 import {Grid, Accordion, Icon, Header, Segment, Table} from "semantic-ui-react";
 import {i18next} from "@translations/invenio_app_rdm/i18next";
-import { withCancel, http } from "react-invenio-forms";
+import { useVersions } from "./VersionsProvider";
 
-export class EndorsementsDisplay extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      activeIndices: [],
-      allVersions: {},
-      versionsLoading: true,
-      versionsError: null
-    };
-    this.cancellableFetch = null;
-  }
+const EndorsementsDisplayContent = ({ record, allVersions, versionsLoading, versionsError }) => {
+  const [activeIndices, setActiveIndices] = React.useState([]);
 
-  componentDidMount() {
-    this.fetchAllVersions();
-  }
-
-  componentWillUnmount() {
-    if (this.cancellableFetch) {
-      this.cancellableFetch.cancel();
-    }
-  }
-
-  fetchAllVersions = async () => {
-    const { record } = this.props;
-
-    if (!record || !record.links || !record.links.versions) {
-      this.setState({ versionsLoading: false, versionsError: "No versions link available" });
-      return;
-    }
-
-    const fetchVersions = async () => {
-      return await http.get(
-        `${record.links.versions}?size=1000&sort=version&allversions=true`,
-        {
-          headers: {
-            Accept: "application/vnd.inveniordm.v1+json",
-          },
-          withCredentials: true,
-        }
-      );
-    };
-
-    this.cancellableFetch = withCancel(fetchVersions());
-
-    try {
-      const result = await this.cancellableFetch.promise;
-
-      let { hits, total } = result.data.hits;
-      hits = hits.map(record => ({
-        id: record.id,
-        version: record.ui.version,
-        index: record.versions.index,
-        is_latest: record.versions.is_latest,
-      }));
-
-      this.setState({
-        allVersions: { hits, total },
-        versionsLoading: false
-      });
-    } catch (error) {
-      if (error !== "UNMOUNTED") {
-        this.setState({
-          versionsError: "An error occurred while fetching the versions.",
-          versionsLoading: false
-        });
-      }
-    }
-  }
-
-  handleAccordionClick = (e, titleProps) => {
+  const handleAccordionClick = (e, titleProps) => {
     const {index} = titleProps;
-    const {activeIndices} = this.state;
     const newIndices = activeIndices.includes(index)
       ? activeIndices.filter(i => i !== index)
       : [...activeIndices, index];
-    this.setState({activeIndices: newIndices});
+    setActiveIndices(newIndices);
   };
 
-  formatDate = (dateString) => {
+  const formatDate = (dateString) => {
     if (!dateString) return "";
     return dateString.substring(0, 10);
   };
 
-  getMostRecent = (list) => {
+  const getMostRecent = (list) => {
     if (!list || list.length === 0) return null;
     return list.sort((a, b) => new Date(b.created) - new Date(a.created))[0];
   };
 
-  getSortedReviews = (reviewList) => {
+  const getSortedReviews = (reviewList) => {
     if (!reviewList) return [];
 
     const grouped = reviewList.reduce((acc, review) => {
@@ -110,15 +43,15 @@ export class EndorsementsDisplay extends Component {
     })).sort((a, b) => b.index - a.index);
   };
 
-  getVersion = (review, versions, latestVersion) => {
+  const getVersion = (review, versions, latestVersion) => {
     if(review.index === latestVersion.index) {
-      return this.getVersionWithIcon(review, versions, latestVersion);
+      return getVersionWithIcon(review, versions, latestVersion);
     }
 
     return 'v' + review.index;
   }
 
-  getVersionWithIcon = (review, versions, latestVersion) => {
+  const getVersionWithIcon = (review, versions, latestVersion) => {
     if(versions === {})
       return <>v{review.index}</>;
 
@@ -142,150 +75,165 @@ export class EndorsementsDisplay extends Component {
 
   };
 
-  render() {
-    const {record} = this.props;
-    const {activeIndices, allVersions, versionsLoading, versionsError} = this.state;
+  // Filter reviewers that have endorsements
+  const validEndorsements = record.endorsements.filter(
+    endorsement => endorsement.endorsement_list.length > 0 || endorsement.review_list.length > 0
+  );
 
-    // Filter reviewers that have endorsements
-    const validEndorsements = record.endorsements.filter(
-      endorsement => endorsement.endorsement_list.length > 0 || endorsement.review_list.length > 0
-    );
+  if (validEndorsements.length === 0) {
+    return null;
+  }
 
-    if (validEndorsements.length === 0) {
-      return null;
+  // Don't render until versions are loaded
+  if (versionsLoading) {
+    return null;
+  }
+
+  // Handle error state
+  if (versionsError) {
+    return null;
+  }
+
+  // Calculate total review count and find most recent review across all reviewers
+  let totalReviewCount = 0;
+  let mostRecentReview = null;
+
+  validEndorsements.forEach(endorsement => {
+    totalReviewCount += endorsement.review_list.length;
+    const recentReview = getMostRecent(endorsement.review_list);
+    if (recentReview && (!mostRecentReview || new Date(recentReview.created) > new Date(mostRecentReview.created))) {
+      mostRecentReview = recentReview;
     }
+  });
 
-    // Don't render until versions are loaded
-    if (versionsLoading) {
-      return null;
-    }
+  const latestVersion = allVersions.hits.find(item => item.is_latest);
 
-    // Handle error state
-    if (versionsError) {
-      return null;
-    }
+  return (
+    <Segment className="ui segment bottom attached rdm-sidebar">
 
-    // Calculate total review count and find most recent review across all reviewers
-    let totalReviewCount = 0;
-    let mostRecentReview = null;
+      {validEndorsements.length > 1 && (
+        <Header as="h4" className="ui small header">
+          {totalReviewCount > 0 && (
+            <span className="ui small text"> {totalReviewCount} {i18next.t(totalReviewCount === 1 ? "review" : "reviews")}</span>
+          )}
+          {mostRecentReview && (
+            <div className="ui normal text mt-5">
+              {i18next.t("Most recent:")}&nbsp;
+              <a href={mostRecentReview.url} target="_blank" rel="noopener noreferrer">
+                {formatDate(mostRecentReview.created)}
+              </a>
+              {latestVersion && (
+                <span> {i18next.t("on")} {getVersionWithIcon(mostRecentReview, allVersions, latestVersion)}</span>
+              )}
+            </div>
+          )}
+        </Header>
+      )}
 
-    validEndorsements.forEach(endorsement => {
-      totalReviewCount += endorsement.review_list.length;
-      const recentReview = this.getMostRecent(endorsement.review_list);
-      if (recentReview && (!mostRecentReview || new Date(recentReview.created) > new Date(mostRecentReview.created))) {
-        mostRecentReview = recentReview;
-      }
-    });
+      {validEndorsements.map((endorsement, endorsementIndex) => {
+        const mostRecentEndorsement = getMostRecent(endorsement.endorsement_list);
+        const mostRecentReview = getMostRecent(endorsement.review_list);
+        const latestVersion = allVersions.hits.find(item => item.is_latest);
+        const sortedReviews = getSortedReviews(endorsement.review_list);
+        const hasReviews = endorsement.review_list.length > 0;
 
-    const latestVersion = allVersions.hits.find(item => item.is_latest);
+        return (<Accordion key={`endorsement-${endorsement.reviewer_id}-${endorsementIndex}`} className="ui fluid accordion segment">
+          <Accordion.Title
+            active={activeIndices.includes(endorsementIndex)}
+            index={endorsementIndex}
+            onClick={hasReviews ? handleAccordionClick : undefined}
+            className="title"
+          >
 
-    return (
-      <Segment className="ui segment bottom attached rdm-sidebar">
+            <Header as="div" className="ui left aligned header small mb-0 trigger">
+              {hasReviews && <Icon name={activeIndices.includes(endorsementIndex) ? "caret down" : "caret right"}/>}
+              {endorsement.reviewer_name}{endorsement.review_count > 0 && ` (${endorsement.review_count})`}
+            </Header>
 
-        {validEndorsements.length > 1 && (
-          <Header as="h4" className="ui small header">
-            {totalReviewCount > 0 && (
-              <span className="ui small text"> {totalReviewCount} {i18next.t(totalReviewCount === 1 ? "review" : "reviews")}</span>
-            )}
-            {mostRecentReview && (
-              <div className="ui normal text mt-5">
-                {i18next.t("Most recent:")}&nbsp;
-                <a href={mostRecentReview.url} target="_blank" rel="noopener noreferrer">
-                  {this.formatDate(mostRecentReview.created)}
+            {mostRecentEndorsement && (
+              <div className="ui center aligned content mt-5">
+                {i18next.t("Endorsement:")}&nbsp;
+                <a href={mostRecentEndorsement.url} target="_blank" rel="noopener noreferrer">
+                  {formatDate(mostRecentEndorsement.created)}
                 </a>
-                {latestVersion && (
-                  <span> {i18next.t("on")} {this.getVersionWithIcon(mostRecentReview, allVersions, latestVersion)}</span>
-                )}
               </div>
             )}
-          </Header>
-        )}
 
-        {validEndorsements.map((endorsement, endorsementIndex) => {
-          const mostRecentEndorsement = this.getMostRecent(endorsement.endorsement_list);
-          const mostRecentReview = this.getMostRecent(endorsement.review_list);
-          const latestVersion = allVersions.hits.find(item => item.is_latest);
-          const sortedReviews = this.getSortedReviews(endorsement.review_list);
-          const hasReviews = endorsement.review_list.length > 0;
+            {mostRecentReview && (
+              <div className="ui center aligned content mt-5">
+                {i18next.t("Most recent review:")}&nbsp;
+                <a href={mostRecentReview.url} target="_blank" rel="noopener noreferrer">
+                  {formatDate(mostRecentReview.created)}
+                </a> {i18next.t("on")} {getVersionWithIcon(mostRecentReview, allVersions, latestVersion)}
+              </div>
+            )}
 
-          return (<Accordion key={`endorsement-${endorsement.reviewer_id}-${endorsementIndex}`} className="ui fluid accordion segment">
-            <Accordion.Title
-              active={activeIndices.includes(endorsementIndex)}
-              index={endorsementIndex}
-              onClick={hasReviews ? this.handleAccordionClick : undefined}
-              className="title"
-            >
-
-              <Header as="div" className="ui left aligned header small mb-0 trigger">
-                {hasReviews && <Icon name={activeIndices.includes(endorsementIndex) ? "caret down" : "caret right"}/>}
-                {endorsement.reviewer_name}{endorsement.review_count > 0 && ` (${endorsement.review_count})`}
-              </Header>
-
-              {mostRecentEndorsement && (
-                <div className="ui center aligned content mt-5">
-                  {i18next.t("Endorsement:")}&nbsp;
-                  <a href={mostRecentEndorsement.url} target="_blank" rel="noopener noreferrer">
-                    {this.formatDate(mostRecentEndorsement.created)}
-                  </a>
-                </div>
-              )}
-
-              {mostRecentReview && (
-                <div className="ui center aligned content mt-5">
-                  {i18next.t("Most recent review:")}&nbsp;
-                  <a href={mostRecentReview.url} target="_blank" rel="noopener noreferrer">
-                    {this.formatDate(mostRecentReview.created)}
-                  </a> {i18next.t("on")} {this.getVersionWithIcon(mostRecentReview, allVersions, latestVersion)}
-                </div>
-              )}
-
-            </Accordion.Title>
-            <Accordion.Content active={activeIndices.includes(endorsementIndex)}>
-              <Table striped unstackable>
-                <Table.Header>
-                  <Table.Row>
-                    <Table.HeaderCell collapsing>{i18next.t("Version")}</Table.HeaderCell>
-                    <Table.HeaderCell>{i18next.t("Reviews")}</Table.HeaderCell>
+          </Accordion.Title>
+          <Accordion.Content active={activeIndices.includes(endorsementIndex)}>
+            <Table striped unstackable>
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell collapsing>{i18next.t("Version")}</Table.HeaderCell>
+                  <Table.HeaderCell>{i18next.t("Reviews")}</Table.HeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {sortedReviews.map((item, itemIndex) => (
+                  <Table.Row key={`review-${item.index}-${itemIndex}`}>
+                    <Table.Cell textAlign="center" className="right bordered">{getVersion(item, allVersions, latestVersion)}</Table.Cell>
+                    <Table.Cell>
+                      <Grid divided compact="true">
+                        {item.reviews.reduce((rows, review, idx) => {
+                          if (idx % 2 === 0) rows.push([]);
+                          rows[rows.length - 1].push(review);
+                          return rows;
+                        }, []).map((rowReviews, rowIdx) => (
+                          <Grid.Row key={`row-${item.index}-${rowIdx}`}>
+                            {rowReviews.map((review, idx) => (
+                              <Grid.Column key={`col-${review.created}-${idx}`} computer={8} tablet={8} mobile={16} textAlign="center">
+                                <a
+                                  href={review.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                >
+                                  {formatDate(review.created)}
+                                </a>
+                              </Grid.Column>
+                            ))}
+                          </Grid.Row>
+                        ))}
+                      </Grid>
+                    </Table.Cell>
                   </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                  {sortedReviews.map((item, itemIndex) => (
-                    <Table.Row key={`review-${item.index}-${itemIndex}`}>
-                      <Table.Cell textAlign="center" className="right bordered">{this.getVersion(item, allVersions, latestVersion)}</Table.Cell>
-                      <Table.Cell>
-                        <Grid divided compact="true">
-                          {item.reviews.reduce((rows, review, idx) => {
-                            if (idx % 2 === 0) rows.push([]);
-                            rows[rows.length - 1].push(review);
-                            return rows;
-                          }, []).map((rowReviews, rowIdx) => (
-                            <Grid.Row key={`row-${item.index}-${rowIdx}`}>
-                              {rowReviews.map((review, idx) => (
-                                <Grid.Column key={`col-${review.created}-${idx}`} computer={8} tablet={8} mobile={16} textAlign="center">
-                                  <a
-                                    href={review.url}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                  >
-                                    {this.formatDate(review.created)}
-                                  </a>
-                                </Grid.Column>
-                              ))}
-                            </Grid.Row>
-                          ))}
-                        </Grid>
-                      </Table.Cell>
-                    </Table.Row>
-                  ))}
-                </Table.Body>
-              </Table>
-            </Accordion.Content>
-          </Accordion>)
-        })}
-      </Segment>
-    );
-  }
-}
+                ))}
+              </Table.Body>
+            </Table>
+          </Accordion.Content>
+        </Accordion>)
+      })}
+    </Segment>
+  );
+};
+
+EndorsementsDisplayContent.propTypes = {
+  record: PropTypes.object.isRequired,
+  allVersions: PropTypes.object.isRequired,
+  versionsLoading: PropTypes.bool.isRequired,
+  versionsError: PropTypes.string,
+};
+
+export const EndorsementsDisplay = ({ record }) => {
+  const { allVersions, versionsLoading, versionsError } = useVersions();
+  
+  return (
+    <EndorsementsDisplayContent 
+      record={record}
+      allVersions={allVersions}
+      versionsLoading={versionsLoading}
+      versionsError={versionsError}
+    />
+  );
+};
 
 EndorsementsDisplay.propTypes = {
   record: PropTypes.object.isRequired,

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordVersionsList.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordVersionsList.js
@@ -13,7 +13,7 @@ import { i18next } from "@translations/invenio_app_rdm/i18next";
 import PropTypes from "prop-types";
 import { Trans } from "react-i18next";
 import { ErrorMessage } from "react-invenio-forms";
-import { useVersions } from "./VersionsProvider";
+import { useSharedVersions } from "./useSharedVersions";
 
 const deserializeRecord = (record) => ({
   id: record.id,
@@ -187,7 +187,7 @@ RecordVersionsListContent.propTypes = {
 };
 
 export const RecordVersionsList = ({ record, isPreview }) => {
-  const { allVersions, versionsLoading, versionsError } = useVersions();
+  const { allVersions, versionsLoading, versionsError } = useSharedVersions(record);
   
   return (
     <RecordVersionsListContent 

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordVersionsList.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordVersionsList.js
@@ -7,12 +7,13 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import _get from "lodash/get";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Grid, Icon, Message, Placeholder, List, Divider } from "semantic-ui-react";
 import { i18next } from "@translations/invenio_app_rdm/i18next";
 import PropTypes from "prop-types";
 import { Trans } from "react-i18next";
-import { withCancel, http, ErrorMessage } from "react-invenio-forms";
+import { ErrorMessage } from "react-invenio-forms";
+import { useVersions } from "./VersionsProvider";
 
 const deserializeRecord = (record) => ({
   id: record.id,
@@ -78,52 +79,19 @@ const PreviewMessage = () => {
   );
 };
 
-export const RecordVersionsList = ({ record, isPreview }) => {
+const RecordVersionsListContent = ({ record, isPreview, allVersions, versionsLoading, versionsError }) => {
   const recordDeserialized = deserializeRecord(record);
   const recordParentDOI = recordDeserialized?.parent?.pids?.doi?.identifier;
   const recordDraftParentDOIFormat = recordDeserialized?.new_draft_parent_doi;
   const recid = recordDeserialized.id;
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
   const [currentRecordInResults, setCurrentRecordInResults] = useState(false);
-  const [recordVersions, setRecordVersions] = useState({});
 
-  useEffect(() => {
-    const fetchVersions = async () => {
-      return await http.get(
-        `${recordDeserialized.links.versions}?size=${NUMBER_OF_VERSIONS}&sort=version&allversions=true`,
-        {
-          headers: {
-            Accept: "application/vnd.inveniordm.v1+json",
-          },
-          withCredentials: true,
-        }
-      );
-    };
-
-    const cancellableFetchVersions = withCancel(fetchVersions());
-
-    async function fetchVersionsAndSetState() {
-      try {
-        const result = await cancellableFetchVersions.promise;
-        let { hits, total } = result.data.hits;
-        hits = hits.map(deserializeRecord);
-        setCurrentRecordInResults(hits.some((record) => record.id === recid));
-        setRecordVersions({ hits, total });
-        setLoading(false);
-      } catch (error) {
-        if (error !== "UNMOUNTED") {
-          setError(i18next.t("An error occurred while fetching the versions."));
-          setLoading(false);
-        }
-      }
+  // Check if current record is in results when versions load
+  React.useEffect(() => {
+    if (!versionsLoading && allVersions.hits) {
+      setCurrentRecordInResults(allVersions.hits.some((record) => record.id === recid));
     }
-    fetchVersionsAndSetState();
-
-    return () => {
-      cancellableFetchVersions?.cancel();
-    };
-  }, [recordDeserialized.links.versions, recid]);
+  }, [allVersions, versionsLoading, recid]);
 
   const loadingcmp = () => {
     return isPreview ? (
@@ -143,13 +111,13 @@ export const RecordVersionsList = ({ record, isPreview }) => {
   };
 
   const errorMessagecmp = () => (
-    <ErrorMessage className="rel-mr-1 rel-ml-1" content={i18next.t(error)} negative />
+    <ErrorMessage className="rel-mr-1 rel-ml-1" content={i18next.t(versionsError)} negative />
   );
 
   const recordVersionscmp = () => (
     <List divided>
       {isPreview ? <PreviewMessage /> : null}
-      {recordVersions.hits.map((item) => (
+      {allVersions.hits.slice(0, NUMBER_OF_VERSIONS).map((item) => (
         <RecordVersionItem
           key={item.id}
           item={item}
@@ -162,7 +130,7 @@ export const RecordVersionsList = ({ record, isPreview }) => {
           <RecordVersionItem item={recordDeserialized} activeVersion />
         </>
       )}
-      {recordVersions.total > 1 && (
+      {allVersions.total > 1 && (
         <Grid className="mt-0">
           <Grid.Row centered>
             <a
@@ -170,7 +138,7 @@ export const RecordVersionsList = ({ record, isPreview }) => {
               className="font-small"
             >
               {i18next.t(`View all {{count}} versions`, {
-                count: recordVersions.total,
+                count: allVersions.total,
               })}
             </a>
           </Grid.Row>
@@ -207,7 +175,29 @@ export const RecordVersionsList = ({ record, isPreview }) => {
     </List>
   );
 
-  return loading ? loadingcmp() : error ? errorMessagecmp() : recordVersionscmp();
+  return versionsLoading ? loadingcmp() : versionsError ? errorMessagecmp() : recordVersionscmp();
+};
+
+RecordVersionsListContent.propTypes = {
+  record: PropTypes.object.isRequired,
+  isPreview: PropTypes.bool.isRequired,
+  allVersions: PropTypes.object.isRequired,
+  versionsLoading: PropTypes.bool.isRequired,
+  versionsError: PropTypes.string,
+};
+
+export const RecordVersionsList = ({ record, isPreview }) => {
+  const { allVersions, versionsLoading, versionsError } = useVersions();
+  
+  return (
+    <RecordVersionsListContent 
+      record={record}
+      isPreview={isPreview}
+      allVersions={allVersions}
+      versionsLoading={versionsLoading}
+      versionsError={versionsError}
+    />
+  );
 };
 
 RecordVersionsList.propTypes = {

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/VersionsProvider.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/VersionsProvider.js
@@ -1,0 +1,88 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import { withCancel, http } from "react-invenio-forms";
+
+const VersionsContext = createContext();
+
+export const useVersions = () => {
+  const context = useContext(VersionsContext);
+  if (!context) {
+    throw new Error("useVersions must be used within a VersionsProvider");
+  }
+  return context;
+};
+
+export const VersionsProvider = ({ record, children }) => {
+  const [allVersions, setAllVersions] = useState({});
+  const [versionsLoading, setVersionsLoading] = useState(true);
+  const [versionsError, setVersionsError] = useState(null);
+
+  useEffect(() => {
+    if (!record || !record.links || !record.links.versions) {
+      setVersionsLoading(false);
+      setVersionsError("No versions link available");
+      return;
+    }
+
+    const fetchVersions = async () => {
+      return await http.get(
+        `${record.links.versions}?size=1000&sort=version&allversions=true`,
+        {
+          headers: {
+            Accept: "application/vnd.inveniordm.v1+json",
+          },
+          withCredentials: true,
+        }
+      );
+    };
+
+    const cancellableFetch = withCancel(fetchVersions());
+
+    cancellableFetch.promise
+      .then((result) => {
+        let { hits, total } = result.data.hits;
+        hits = hits.map(record => ({
+          id: record.id,
+          parent: record.parent,
+          parent_id: record.parent.id,
+          publication_date: record.ui.publication_date_l10n_medium,
+          version: record.ui.version,
+          links: record.links,
+          pids: record.pids,
+          new_draft_parent_doi: record.ui.new_draft_parent_doi,
+          index: record.versions.index,
+          is_latest: record.versions.is_latest,
+        }));
+
+        setAllVersions({ hits, total });
+        setVersionsLoading(false);
+      })
+      .catch((error) => {
+        if (error !== "UNMOUNTED") {
+          setVersionsError("An error occurred while fetching the versions.");
+          setVersionsLoading(false);
+        }
+      });
+
+    return () => {
+      cancellableFetch.cancel();
+    };
+  }, [record]);
+
+  const value = {
+    allVersions,
+    versionsLoading,
+    versionsError,
+  };
+
+  return (
+    <VersionsContext.Provider value={value}>
+      {children}
+    </VersionsContext.Provider>
+  );
+};
+
+VersionsProvider.propTypes = {
+  record: PropTypes.object.isRequired,
+  children: PropTypes.node.isRequired,
+};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/VersionsStore.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/VersionsStore.js
@@ -1,0 +1,105 @@
+import { withCancel, http } from "react-invenio-forms";
+
+// Global versions store to share data across multiple React trees
+class VersionsStore {
+  constructor() {
+    this.subscribers = new Set();
+    this.state = {
+      allVersions: {},
+      versionsLoading: true,
+      versionsError: null,
+    };
+    this.fetchPromise = null;
+    this.currentRecord = null;
+  }
+
+  subscribe(callback) {
+    this.subscribers.add(callback);
+    return () => this.subscribers.delete(callback);
+  }
+
+  getState() {
+    return this.state;
+  }
+
+  setState(newState) {
+    this.state = { ...this.state, ...newState };
+    this.subscribers.forEach(callback => callback(this.state));
+  }
+
+  async fetchVersions(record) {
+    // Return existing promise if already fetching for the same record
+    if (this.fetchPromise && this.currentRecord?.id === record?.id) {
+      return this.fetchPromise;
+    }
+
+    // If record changed, reset state
+    if (this.currentRecord?.id !== record?.id) {
+      this.setState({
+        allVersions: {},
+        versionsLoading: true,
+        versionsError: null,
+      });
+    }
+
+    this.currentRecord = record;
+
+    if (!record || !record.links || !record.links.versions) {
+      this.setState({
+        versionsLoading: false,
+        versionsError: "No versions link available",
+      });
+      return Promise.resolve();
+    }
+
+    const fetchVersions = async () => {
+      return await http.get(
+        `${record.links.versions}?size=1000&sort=version&allversions=true`,
+        {
+          headers: {
+            Accept: "application/vnd.inveniordm.v1+json",
+          },
+          withCredentials: true,
+        }
+      );
+    };
+
+    const cancellableFetch = withCancel(fetchVersions());
+    this.fetchPromise = cancellableFetch.promise;
+
+    cancellableFetch.promise
+      .then((result) => {
+        let { hits, total } = result.data.hits;
+        hits = hits.map(record => ({
+          id: record.id,
+          parent: record.parent,
+          parent_id: record.parent.id,
+          publication_date: record.ui.publication_date_l10n_medium,
+          version: record.ui.version,
+          links: record.links,
+          pids: record.pids,
+          new_draft_parent_doi: record.ui.new_draft_parent_doi,
+          index: record.versions.index,
+          is_latest: record.versions.is_latest,
+        }));
+
+        this.setState({
+          allVersions: { hits, total },
+          versionsLoading: false,
+        });
+      })
+      .catch((error) => {
+        if (error !== "UNMOUNTED") {
+          this.setState({
+            versionsError: "An error occurred while fetching the versions.",
+            versionsLoading: false,
+          });
+        }
+      });
+
+    return this.fetchPromise;
+  }
+}
+
+// Export singleton instance
+export const versionsStore = new VersionsStore();

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
@@ -16,7 +16,6 @@ import { ExportDropdown } from "./ExportDropdown";
 import { EndorsementRequestDropdown } from "./EndorsementRequestDropdown";
 import { EndorsementsDisplay } from "./EndorsementsDisplay";
 import { CommunitiesManagement } from "./CommunitiesManagement";
-import { VersionsProvider } from "./VersionsProvider";
 import Overridable, { OverridableContext, overrideStore } from "react-overridable";
 
 const recordManagementAppDiv = document.getElementById("recordManagement");
@@ -57,28 +56,24 @@ function renderRecordManagement(element) {
   );
 }
 
-if (recordVersionsAppDiv || recordEndorsementDisplayDiv) {
-  const record = recordVersionsAppDiv 
-    ? JSON.parse(recordVersionsAppDiv.dataset.record)
-    : JSON.parse(recordEndorsementDisplayDiv.dataset.record);
-
-  const VersionsWrapper = () => (
-    <VersionsProvider record={record}>
-      {recordVersionsAppDiv && (
-        <RecordVersionsList
-          record={record}
-          isPreview={JSON.parse(recordVersionsAppDiv.dataset.preview)}
-        />
-      )}
-      {recordEndorsementDisplayDiv && (
-        <EndorsementsDisplay record={record} />
-      )}
-    </VersionsProvider>
+// Handle versions sidebar
+if (recordVersionsAppDiv) {
+  const record = JSON.parse(recordVersionsAppDiv.dataset.record);
+  ReactDOM.render(
+    <RecordVersionsList
+      record={record}
+      isPreview={JSON.parse(recordVersionsAppDiv.dataset.preview)}
+    />,
+    recordVersionsAppDiv
   );
+}
 
-  if (recordVersionsAppDiv) {
-    ReactDOM.render(<VersionsWrapper />, recordVersionsAppDiv);
-  }
+if (recordEndorsementDisplayDiv) {
+  const record = JSON.parse(recordEndorsementDisplayDiv.dataset.record);
+  ReactDOM.render(
+    <EndorsementsDisplay record={record} />,
+    recordEndorsementDisplayDiv
+  );
 }
 
 if (recordCitationAppDiv) {
@@ -113,15 +108,6 @@ if (recordEndorsementRequestDiv
   );
 }
 
-if (recordEndorsementDisplayDiv && !recordVersionsAppDiv) {
-  const record = JSON.parse(recordEndorsementDisplayDiv.dataset.record);
-  ReactDOM.render(
-    <VersionsProvider record={record}>
-      <EndorsementsDisplay record={record} />
-    </VersionsProvider>,
-    recordEndorsementDisplayDiv
-  );
-}
 
 if (sidebarCommunitiesManageDiv) {
   const recordCommunitySearchConfig = JSON.parse(

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
@@ -16,6 +16,7 @@ import { ExportDropdown } from "./ExportDropdown";
 import { EndorsementRequestDropdown } from "./EndorsementRequestDropdown";
 import { EndorsementsDisplay } from "./EndorsementsDisplay";
 import { CommunitiesManagement } from "./CommunitiesManagement";
+import { VersionsProvider } from "./VersionsProvider";
 import Overridable, { OverridableContext, overrideStore } from "react-overridable";
 
 const recordManagementAppDiv = document.getElementById("recordManagement");
@@ -56,14 +57,28 @@ function renderRecordManagement(element) {
   );
 }
 
-if (recordVersionsAppDiv) {
-  ReactDOM.render(
-    <RecordVersionsList
-      record={JSON.parse(recordVersionsAppDiv.dataset.record)}
-      isPreview={JSON.parse(recordVersionsAppDiv.dataset.preview)}
-    />,
-    recordVersionsAppDiv
+if (recordVersionsAppDiv || recordEndorsementDisplayDiv) {
+  const record = recordVersionsAppDiv 
+    ? JSON.parse(recordVersionsAppDiv.dataset.record)
+    : JSON.parse(recordEndorsementDisplayDiv.dataset.record);
+
+  const VersionsWrapper = () => (
+    <VersionsProvider record={record}>
+      {recordVersionsAppDiv && (
+        <RecordVersionsList
+          record={record}
+          isPreview={JSON.parse(recordVersionsAppDiv.dataset.preview)}
+        />
+      )}
+      {recordEndorsementDisplayDiv && (
+        <EndorsementsDisplay record={record} />
+      )}
+    </VersionsProvider>
   );
+
+  if (recordVersionsAppDiv) {
+    ReactDOM.render(<VersionsWrapper />, recordVersionsAppDiv);
+  }
 }
 
 if (recordCitationAppDiv) {
@@ -98,10 +113,12 @@ if (recordEndorsementRequestDiv
   );
 }
 
-if (recordEndorsementDisplayDiv) {
+if (recordEndorsementDisplayDiv && !recordVersionsAppDiv) {
+  const record = JSON.parse(recordEndorsementDisplayDiv.dataset.record);
   ReactDOM.render(
-    <EndorsementsDisplay
-      record={JSON.parse(recordEndorsementDisplayDiv.dataset.record)}/>,
+    <VersionsProvider record={record}>
+      <EndorsementsDisplay record={record} />
+    </VersionsProvider>,
     recordEndorsementDisplayDiv
   );
 }

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/useSharedVersions.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/useSharedVersions.js
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+import { versionsStore } from "./VersionsStore";
+
+export const useSharedVersions = (record) => {
+  const [state, setState] = useState(versionsStore.getState());
+
+  useEffect(() => {
+    // Subscribe to store updates
+    const unsubscribe = versionsStore.subscribe(setState);
+
+    // Fetch versions if not already loading/loaded for this record
+    versionsStore.fetchVersions(record);
+
+    return unsubscribe;
+  }, [record]);
+
+  return state;
+};


### PR DESCRIPTION
This PR provides a new React component, Versions Provider in order not to make duplicate calls to the versions endpoint if a landing page both has multiple versions as well as well as reviews/endorsements